### PR TITLE
Run composer vendor binaries without typing vendor/bin

### DIFF
--- a/roles/dotfiles/templates/zshrc.j2
+++ b/roles/dotfiles/templates/zshrc.j2
@@ -17,7 +17,7 @@ export PATH=$HOME/bin:/usr/local/bin:/usr/local/sbin:$PATH
 [ -e "${HOME}/.load_php" ] && source "${HOME}/.load_php"
 
 # Composer binaries
-export PATH=~/.composer/vendor/bin:$PATH
+export PATH=~/.composer/vendor/bin:./vendor/bin:$PATH
 
 export REQUESTS_CA_BUNDLE=/usr/local/etc/openssl/cert.pem
 


### PR DESCRIPTION
Add ./vendor/bin to PATH