### PR TITLE
move upgrade tasks to a specific role to avoid issue with php upgrade

### DIFF
--- a/playbooks/setup.yml
+++ b/playbooks/setup.yml
@@ -26,4 +26,5 @@
     - composer
     - nginx
     - mailhog
+    - upgrade
     - cleanup

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -57,13 +57,3 @@
   command: mas install "{{ item.id|default(item) }}"
   with_items: "{{ mas_installed_apps }}"
   when: (item.id | default(item) | string) not in mas_list.stdout
-
-- name: Upgrade all mas apps (if configured)
-  command: mas upgrade
-  when: mas_upgrade_all_apps
-
-- name: Mise à jour des binaires
-  homebrew:
-    update_homebrew: yes
-    upgrade_all: yes
-  when: upgrade_all_packages

--- a/roles/upgrade/tasks/main.yml
+++ b/roles/upgrade/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Upgrade all mas apps (if configured)
+  command: mas upgrade
+  when: mas_upgrade_all_apps
+
+- name: Upgrade all binaries
+  homebrew:
+    update_homebrew: yes
+    upgrade_all: yes
+  when: upgrade_all_packages


### PR DESCRIPTION
Role `php` is configured to install php 7.2 but this fails because :

* package `php`(7.2) is installed
* dev upgrade
  * upgrade all binaries -> package php is updated to 7.3
  * install php -> install package `php@7.2`
* PHP 7.2 and 7.3 are installed

With this fix:

* package `php`(7.2) is installed
* dev upgrade
  * install php -> install package `php@7.2`
  * upgrade all binaries -> no upgrade for php package
* PHP 7.2 is installed