### PR TITLE
Use homebrew/cask-* instead of caskroom/*

### DIFF
--- a/roles/common/vars/main.yml
+++ b/roles/common/vars/main.yml
@@ -2,8 +2,8 @@
 homebrew_tap:
   - homebrew/services
   - buo/cask-upgrade
-  - caskroom/fonts
-  - caskroom/versions
+  - homebrew/cask-fonts
+  - homebrew/cask-versions
 
 homebrew_base_packages:
   - coreutils


### PR DESCRIPTION
Fix the following issue:

```
Error: Cask java8 exists in multiple taps:
  homebrew/cask-versions/java8
  caskroom/versions/java8
```

Ref: https://github.com/Homebrew/homebrew-cask/issues/41990#issuecomment-389009850.