### PR TITLE
Fix issue while trying to install curl with option --with-openssl

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -11,11 +11,6 @@
     update_homebrew: yes
   when: upgrade_all_packages
 
-- name: Installation de curl avec OpenSSL
-  homebrew:
-    name: curl-openssl
-    state: "{{ homebrew_package_state }}"
-
 - name: Installation des paquets avec homebrew
   homebrew:
     name: '{{ homebrew_base_packages + homebrew_packages|default([]) }}'

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -11,29 +11,10 @@
     update_homebrew: yes
   when: upgrade_all_packages
 
-- name: Récupération de la version de Curl
-  command: /usr/local/opt/curl/bin/curl -V
-  register: curl_version
-  ignore_errors: true
-  changed_when: False
-  args:
-    warn: false
-
-- name: Suppression de la version de curl avec SecureTransport
-  homebrew:
-    name: curl
-    state: absent
-  when: "'SecureTransport' in curl_version.stdout|default('')"
-  ignore_errors: true
-
 - name: Installation de curl avec OpenSSL
   homebrew:
-    name: curl
+    name: curl-openssl
     state: "{{ homebrew_package_state }}"
-    install_options: with-openssl
-
-- name: On force l'utilisation de curl avec OpenSSL
-  command: brew link curl --force
 
 - name: Installation des paquets avec homebrew
   homebrew:

--- a/roles/common/vars/main.yml
+++ b/roles/common/vars/main.yml
@@ -6,6 +6,7 @@ homebrew_tap:
   - caskroom/versions
 
 homebrew_base_packages:
+  - curl-openssl
   - coreutils
   - pwgen
   - git


### PR DESCRIPTION
Fix the following error:

```
Error: invalid option: --with-openssl
```

`--with-openssl` option have been removed from curl formula (see https://github.com/Homebrew/homebrew-core/commit/0bfb0391d7c2db964a2da4d31a2495d91361df8a#diff-a7a59ba41131628f779debf43858c613).