### PR TITLE
Remove nginx specific location block for favicon

### DIFF
--- a/roles/nginx/templates/conf/laravel.j2
+++ b/roles/nginx/templates/conf/laravel.j2
@@ -1,10 +1,5 @@
 {{ ansible_managed | comment }}
 
-location = /favicon.ico {
-    log_not_found off;
-    access_log off;
-}
-
 location = /robots.txt {
     allow all;
     log_not_found off;

--- a/roles/nginx/templates/conf/symfony-flex.j2
+++ b/roles/nginx/templates/conf/symfony-flex.j2
@@ -1,10 +1,5 @@
 {{ ansible_managed | comment }}
 
-location = /favicon.ico {
-    log_not_found off;
-    access_log off;
-}
-
 location = /robots.txt {
     allow all;
     log_not_found off;

--- a/roles/nginx/templates/conf/symfony.j2
+++ b/roles/nginx/templates/conf/symfony.j2
@@ -1,10 +1,5 @@
 {{ ansible_managed | comment }}
 
-location = /favicon.ico {
-    log_not_found off;
-    access_log off;
-}
-
 location = /robots.txt {
     allow all;
     log_not_found off;

--- a/roles/nginx/templates/conf/wordpress.j2
+++ b/roles/nginx/templates/conf/wordpress.j2
@@ -3,11 +3,6 @@
 ## This should be in your http block and if it is, it's not needed here.
 index index.php;
 
-location = /favicon.ico {
-        log_not_found off;
-        access_log off;
-}
-
 location = /robots.txt {
         allow all;
         log_not_found off;


### PR DESCRIPTION
I can't remember why we added this location block. But it seem's that this was a hack for missing things or to protect us against strange browser behaviors. 